### PR TITLE
Add berth type to buildings in QGIS project file

### DIFF
--- a/sources/qgis.qgs
+++ b/sources/qgis.qgs
@@ -19349,6 +19349,9 @@ def my_form_open(dialog, layer, feature):
                   <Option type="Map">
                     <Option name="bridge" type="QString" value="bridge"></Option>
                   </Option>
+                  <Option type="Map">
+                    <Option name="berth (docks, piers)" type="QString" value="berth"></Option>
+                  </Option>
                 </Option>
               </Option>
             </config>


### PR DESCRIPTION
Add the `berth` type value as an option for buildings in the QGIS project file, consistent with usage by existing features on the layer.