### PR TITLE
Replace FCP reference in frontend info with CUP

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -43,7 +43,7 @@ export const map = new Map({
     sources: {
       golarion: {
         type: 'vector',
-        attribution: '<a href="https://paizo.com/licenses/fancontent">Paizo FCP</a>, <a href="https://github.com/pf-wikis/mapping#acknowledgments">Acknowledgments</a>',
+        attribution: '<a href="https://paizo.com/licenses/communityuse">Paizo CUP</a>, <a href="https://github.com/pf-wikis/mapping#acknowledgments">Acknowledgments</a>',
         url: 'pmtiles://'+root+'golarion.pmtiles?v='+import.meta.env.VITE_DATA_HASH
       }
     },


### PR DESCRIPTION
The attribution info still links to the FCP. Revert it to the CUP.

![image](https://github.com/user-attachments/assets/efe6a810-d5ff-40e2-8447-0c0afd5015c0)
