### PR TITLE
Add the FullscreenControl to embedded maps

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,4 +1,4 @@
-import Maplibre, { AttributionControl, Map, NavigationControl, ScaleControl } from "maplibre-gl";
+import Maplibre, { AttributionControl, Map, NavigationControl, ScaleControl, FullscreenControl } from "maplibre-gl";
 import 'maplibre-gl/dist/maplibre-gl.css';
 
 import layers from './layers.js';
@@ -65,6 +65,8 @@ map.on('error', function(err) {
 });
 if(!embedded) {
   map.addControl(new NavigationControl({showCompass: false}));
+} else  {
+  map.addControl(new FullscreenControl());
 }
 map.addControl(new ScaleControl({
   unit: 'imperial',


### PR DESCRIPTION
Enable and add the [FullscreenControl](https://maplibre.org/maplibre-gl-js/docs/API/classes/FullscreenControl/) to toggle the map in and out of fullscreen, and display it only on embedded maps. This allows users who encounter the map via embed to interact with the full map.

![image](https://github.com/user-attachments/assets/db6db150-dedf-4872-9845-f4eabd5be8f9)

Note that this PR alone will not enable this functionality. Widget:Map also must be updated to add the `allowfullscreen` parameter to the `iframe` tag, i.e.:

``` diff
- </noinclude><includeonly><div class="map-widget-container" data-track-content data-content-name="Golarion Map" data-content-piece="Map"><iframe class="map-widget" loading="lazy" src="https://map.pathfinderwiki.com/#location=<!--{$zoom|default:7|replace:' ':''|validate:'float'}-->/<!--{if $latlong}--><!--{$latlong|regex_replace:'/,.*/':''|replace:' ':''|validate:'float'}--><!--{else}--><!--{$lat|replace:' ':''|validate:'float'}--><!--{/if}-->/<!--{if $latlong}--><!--{$latlong|regex_replace:'/.*,/':''|replace:' ':''|validate:'float'}--><!--{else}--><!--{$long|replace:' ':''|validate:'float'}--><!--{/if}-->&embedded=true" loading="lazy" style="height:<!--{$height|escape:'html'|default:'200px'}-->;width:<!--{$width|escape:'html'|default:'100%'}-->"
+ </noinclude><includeonly><div class="map-widget-container" data-track-content data-content-name="Golarion Map" data-content-piece="Map"><iframe class="map-widget" loading="lazy" src="https://map.pathfinderwiki.com/#location=<!--{$zoom|default:7|replace:' ':''|validate:'float'}-->/<!--{if $latlong}--><!--{$latlong|regex_replace:'/,.*/':''|replace:' ':''|validate:'float'}--><!--{else}--><!--{$lat|replace:' ':''|validate:'float'}--><!--{/if}-->/<!--{if $latlong}--><!--{$latlong|regex_replace:'/.*,/':''|replace:' ':''|validate:'float'}--><!--{else}--><!--{$long|replace:' ':''|validate:'float'}--><!--{/if}-->&embedded=true" loading="lazy" allowfullscreen style="height:<!--{$height|escape:'html'|default:'200px'}-->;width:<!--{$width|escape:'html'|default:'100%'}-->"
  ></iframe></div></includeonly>
```