### PR TITLE
Close var in code

### DIFF
--- a/tile-compiler/src/main/java/io/github/pfwikis/layercompiler/steps/CreateSearchIndex.java
+++ b/tile-compiler/src/main/java/io/github/pfwikis/layercompiler/steps/CreateSearchIndex.java
@@ -92,14 +92,15 @@ public class CreateSearchIndex extends LCStep {
     	LCContent.MAPPER.writeValue(new File(this.getCtx().getOptions().targetDirectory(), "search.json"), res);
     	var t = this.getCtx().getOptions().targetDirectory();
     	try(
-    			var raw = new FileOutputStream(new File(t, "search.json"));
-    			var gz = new GZIPOutputStream(new FileOutputStream(new File(t, "search.json.gz")));
-    			var out = new TeeOutputStream(raw, gz)
-    	) {
-    		LCContent.MAPPER.writeValue(out, res);
-    	}
+    			try (var raw = new FileOutputStream(new File(t, "search.json"))) {
+    				    			var gz = new GZIPOutputStream(new FileOutputStream(new File(t, "search.json.gz")));
+    				    			var out = new TeeOutputStream(raw, gz)
+    				    	) {
+    				    		LCContent.MAPPER.writeValue(out, res);
+    				    	}
     	
-    	return LCContent.empty();
+    				    	return LCContent.empty();
+    			}
     }
 
 	private double[] toArray(BBox box) {


### PR DESCRIPTION
The code around line 95 in tile-compiler/src/main/java/io/github/pfwikis/layercompiler/steps/CreateSearchIndex.java looked off. the resource opened there can leak if code exits on an error path. I moved the allocation into try-with-resources so cleanup happens on every exit path.